### PR TITLE
Rewrite the README, and fix the broken build plus dead hover styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Month and weekday labels switch between **English / 中文 / Melayu / Tiếng Vi
 | **Today, triangulated** | The current month chip, today's date, and the weekday cell where they intersect are all highlighted at once. |
 | **Crosshair tracing** | Hovering any weekday cell lights its full row and column, so you can follow a lookup without losing your place. |
 | **31-day markers** | Months with 31 days are underlined, as is date `31` — a reminder that not every column runs to the bottom. |
-| **Elapsed days dimmed** | In the current year, dates before today are greyed out. |
+| **Elapsed day numbers dimmed** | In the current year, day numbers below today's are greyed out. This is a day-of-month comparison, not a date comparison — the date block is shared by all 12 months, so it dims the 3rd of December just as readily as the 3rd of January. See #6. |
 | **Sunday in red** | Across all 7 rotations, so the weekend edge stays findable in a rotated grid. |
 | **4 languages** | English · 中文 · Melayu · Tiếng Việt, switchable live. |
 | **No dependencies for the math** | ~270 lines, native `Date` only — no moment, no date-fns, no timezone surprises. |
@@ -138,15 +138,24 @@ The lockfile resolves ESLint to 9.15 while `typescript-eslint` is pinned at `^8.
 `vite.config.ts` sets `base: '/'`, but a GitHub Pages project site serves from `/perpetual-calendars/`. Set `base: '/perpetual-calendars/'` (or derive it from `import.meta.env`). Relatedly, `package.json#homepage` is still the boilerplate placeholder `https://username.github.io/react-tailwind-boilerplate/`, and `name` is still `react-tailwind-boilerplate`.
 
 **4. The workflow needs a PAT it may not have.**
-`deploy.yml` authenticates with `secrets.PERSONAL_ACCESS_TOKEN`. The built-in `github_token: ${{ secrets.GITHUB_TOKEN }}` works for same-repo Pages deploys and needs no secret management.
+`deploy.yml` authenticates with `secrets.PERSONAL_ACCESS_TOKEN`. The built-in `github_token: ${{ secrets.GITHUB_TOKEN }}` covers same-repo Pages deploys with no secret management — but it is not a pure drop-in: the workflow declares no `permissions` block, so on a repository whose default workflow token is read-only it still cannot push `gh-pages`. Add the grant explicitly:
+
+```yaml
+permissions:
+  contents: write
+```
 
 **5. `index.html` is unbranded.**
 Title is still `Vite + React + TS`, the favicon is `vite.svg`, and there is no description or Open Graph tag — which matters for a tool whose main distribution channel is a shared link.
 
 ### Correctness and UX
 
-**6. Month lengths aren't modelled.**
-The date block always shows 1–31. February (28/29) and the 30-day months aren't masked, and leap years get no indication — the reader has to supply that knowledge. Dimming out-of-range dates for the hovered month would close the gap.
+**6. The date axis is month-agnostic, but two features treat it as month-specific.**
+The date block always shows 1–31 for every month. February (28/29) and the 30-day months aren't masked, and leap years get no indication — the reader has to supply that knowledge.
+
+The same gap makes `isPastDate()` misleading: it tests `num < currentDate`, a day-of-month comparison on cells that belong to all twelve months at once. Late in a month it dims day numbers that are still in the future for every later month, while the 29th–31st of already-elapsed months stay undimmed. `isToday()` has the same shape. Both read as "past/today" but only mean "lower-numbered than today".
+
+Dimming out-of-range and elapsed dates relative to a *hovered or selected month* would fix the month-length gap and the comparison gap together.
 
 **7. i18n logic matches on translated strings, not indices.**
 `hasThirtyOneDays()` keeps four parallel arrays of localized month names, and the Sunday-red test is a string check (`day.includes('Sun') || day.includes('周日') || day.includes('Ahd') || day === 'CN'`). Adding a fifth language means editing string lists in two more places, and any label collision across locales silently mis-renders. Both should key off the month/weekday **index**, which is already available.

--- a/README.md
+++ b/README.md
@@ -88,18 +88,18 @@ npm run dev
 
 Open <http://localhost:5173>.
 
-> **Heads up:** `npm run build`, `npm run lint`, and `npm start` currently fail on a clean checkout. `npm run dev` works. See [Known issues](#known-issues) for the one-line fixes.
+> **Heads up:** `npm run lint` and `npm start` still fail on a clean checkout. `npm run dev` and `npm run build` work. See [Known issues](#known-issues) for the one-line fixes.
 
 ### Scripts
 
 | Script | What it does | Status |
 |---|---|---|
 | `npm run dev` | Vite dev server with HMR | ✅ works |
-| `npm run build` | `tsc -b && vite build` → `dist/` | ❌ fails — see #1 |
-| `npm run preview` | Serve the production build locally | ✅ (after a successful build) |
-| `npm run lint` | ESLint over the repo | ❌ crashes — see #2 |
-| `npm start` | Serve `dist/` via Express | ❌ fails — see #3 |
-| `npm run deploy` | `gh-pages -d dist` | ⚠️ depends on `build` |
+| `npm run build` | `tsc -b && vite build` → `dist/` | ✅ works |
+| `npm run preview` | Serve the production build locally | ✅ works |
+| `npm run lint` | ESLint over the repo | ❌ crashes — see #1 |
+| `npm start` | Serve `dist/` via Express | ❌ fails — see #2 |
+| `npm run deploy` | `gh-pages -d dist` | ✅ works (see #3 for the base path caveat) |
 
 ### Project layout
 
@@ -122,73 +122,61 @@ Everything meaningful lives in `CalendarBuilder.tsx`. The functions worth knowin
 
 ## Known issues
 
-Verified against a clean `npm ci` on this branch. The first three block the standard workflow, so they're listed with their fixes.
+Verified against a clean `npm ci` on this branch. The first two block the standard workflow, so they're listed with their fixes.
 
 ### Blocking
 
-**1. `npm run build` fails — and takes CI down with it.**
-`tsconfig.app.json` sets `noUnusedLocals` / `noUnusedParameters`, and four symbols are unused:
-
-```
-src/App.tsx(1,1)                     'useState' is declared but never read
-src/components/CalendarBuilder.tsx(1,8)   'React' is declared but never read
-src/components/CalendarBuilder.tsx(1,27)  'useEffect' is declared but never read
-src/components/CalendarBuilder.tsx(28,9)  'currentDay' is declared but never read
-```
-
-Deleting those four declarations fixes it. Because `.github/workflows/deploy.yml` runs `npm run build`, **the deploy workflow fails on every push to `main`** — there is currently no published site.
-
-**2. `npm run lint` crashes.**
+**1. `npm run lint` crashes.**
 The lockfile resolves ESLint to 9.15 while `typescript-eslint` is pinned at `^8.7`; the `no-unused-expressions` rule then throws `Cannot read properties of undefined (reading 'allowShortCircuit')`. Bump `typescript-eslint` to `^8.15`.
 
-**3. `npm start` fails.**
+**2. `npm start` fails.**
 `server.js` does `import express from 'express'`, but `express` is in neither `dependencies` nor the lockfile. Either add it or drop `server.js` — `npm run preview` already covers local production serving.
 
 ### Deployment
 
-**4. Asset paths will 404 on a project page.**
+**3. Asset paths will 404 on a project page.**
 `vite.config.ts` sets `base: '/'`, but a GitHub Pages project site serves from `/perpetual-calendars/`. Set `base: '/perpetual-calendars/'` (or derive it from `import.meta.env`). Relatedly, `package.json#homepage` is still the boilerplate placeholder `https://username.github.io/react-tailwind-boilerplate/`, and `name` is still `react-tailwind-boilerplate`.
 
-**5. The workflow needs a PAT it may not have.**
+**4. The workflow needs a PAT it may not have.**
 `deploy.yml` authenticates with `secrets.PERSONAL_ACCESS_TOKEN`. The built-in `github_token: ${{ secrets.GITHUB_TOKEN }}` works for same-repo Pages deploys and needs no secret management.
 
-**6. `index.html` is unbranded.**
+**5. `index.html` is unbranded.**
 Title is still `Vite + React + TS`, the favicon is `vite.svg`, and there is no description or Open Graph tag — which matters for a tool whose main distribution channel is a shared link.
 
 ### Correctness and UX
 
-**7. Month lengths aren't modelled.**
+**6. Month lengths aren't modelled.**
 The date block always shows 1–31. February (28/29) and the 30-day months aren't masked, and leap years get no indication — the reader has to supply that knowledge. Dimming out-of-range dates for the hovered month would close the gap.
 
-**8. i18n logic matches on translated strings, not indices.**
+**7. i18n logic matches on translated strings, not indices.**
 `hasThirtyOneDays()` keeps four parallel arrays of localized month names, and the Sunday-red test is a string check (`day.includes('Sun') || day.includes('周日') || day.includes('Ahd') || day === 'CN'`). Adding a fifth language means editing string lists in two more places, and any label collision across locales silently mis-renders. Both should key off the month/weekday **index**, which is already available.
 
-**9. The crosshair is hover-only.**
+**8. The crosshair is hover-only.**
 `onMouseEnter`/`onMouseLeave` means touch and keyboard users get no tracing aid at all — on mobile, the single most useful interaction is simply absent. Tap-to-pin plus focus/arrow-key navigation would fix both.
 
-**10. The mobile layout is a rotation hack.**
+**9. The mobile layout is a rotation hack.**
 Below 768px the whole component is `rotate(90deg) translate(0,-100%)`, which turns the page sideways rather than reflowing. It breaks scroll direction and text selection. A responsive grid or horizontal scroll container would behave properly.
 
-**11. Accessibility gaps.**
+**10. Accessibility gaps.**
 The grid is a `<table>` with no `<th>`, `<caption>`, or `scope` attributes, so screen readers can't announce the row/column relationship the entire design depends on. State (today, past, highlighted) is conveyed by color alone, and the language `<select>` has no associated label.
 
-**12. Nothing is persisted or shareable.**
+**11. Nothing is persisted or shareable.**
 Year and language reset on every reload. Reading them from the URL (`?year=2027&lang=zh`) and mirroring to `localStorage` would make a specific view linkable.
 
-**13. No print stylesheet.**
+**12. No print stylesheet.**
 For a calendar whose entire premise is fitting on one page, `@media print` is a conspicuous omission.
 
 ### Housekeeping
 
-**14. Boilerplate residue.** `src/App.css` still ships an unused `.spin-slow` animation; `src/assets/react.svg` and `public/vite.svg` are unused.
-**15. No tests.** The date math (`getMonthPositions`, `generateWeekdayGrid`) is pure and takes a number, returns an array — near-zero-friction to test, and it's the part that must never be wrong.
-**16. No LICENSE file.** The previous README advertised MIT, but no license file was ever committed. See [License](#license).
+**13. Boilerplate residue.** `src/App.css` still ships an unused `.spin-slow` animation; `src/assets/react.svg` and `public/vite.svg` are unused.
+**14. No tests.** The date math (`getMonthPositions`, `generateWeekdayGrid`) is pure and takes a number, returns an array — near-zero-friction to test, and it's the part that must never be wrong.
+**15. No LICENSE file.** The previous README advertised MIT, but no license file was ever committed. See [License](#license).
 
 ---
 
 ## Deployment
 
-`.github/workflows/deploy.yml` builds on every push to `main` and publishes `dist/` to the `gh-pages` branch via `peaceiris/actions-gh-pages`. Once issues #1, #4, and #5 are resolved, the site will serve from `https://tanghoong.github.io/perpetual-calendars/`.
+`.github/workflows/deploy.yml` builds on every push to `main` and publishes `dist/` to the `gh-pages` branch via `peaceiris/actions-gh-pages`. Once issues #3 and #4 are resolved, the site will serve from `https://tanghoong.github.io/perpetual-calendars/`.
 
 Manual alternative:
 
@@ -200,7 +188,7 @@ npm run deploy   # runs predeploy → build, then pushes dist/ to gh-pages
 
 ## Contributing
 
-Issues and pull requests are welcome. The [Known issues](#known-issues) list is roughly in priority order — items 1–3 are small, self-contained, and unblock everyone else.
+Issues and pull requests are welcome. The [Known issues](#known-issues) list is roughly in priority order — items 1–4 are small, self-contained, and unblock everyone else.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,113 +1,209 @@
-# My React Tailwind Project
+# One Page Calendar
 
-This project is a modern web application built with React, Vite, Tailwind CSS, and Lucide React icons. It's designed for efficient development and seamless deployment to GitHub Pages.
+A whole year on a single grid. No 12 month-blocks, no scrolling, no reprinting every January.
+
+A conventional calendar spends 12 separate grids to encode one fact per date: *which weekday is it?* This app encodes the same year in **one 7×12 lookup table** — find the month's column, find the date's row, read the weekday where they cross. Change the year and only the month labels move; the rest of the grid never changes, because it can't.
+
+Built with React + TypeScript + Vite + Tailwind. Fully client-side, no backend, no date library — just `Date` and modular arithmetic.
+
+---
+
+## The problems it solves
+
+**1. "What weekday is the 25th?" costs a scroll and a scan.**
+On a normal calendar you have to find the right month block, then visually walk the grid. Here it is one intersection: two coordinates, one cell.
+
+**2. A year needs twelve grids — and next year needs twelve more.**
+Each month block is 90% redundant with the others. This layout factors that redundancy out: the date block and weekday block are *year-invariant*, and only the 12 month labels re-flow when the year changes. That is why a single page works as a perpetual calendar.
+
+**3. Cross-month patterns are invisible on a normal calendar.**
+Months that start on the same weekday have byte-identical layouts — but on a normal calendar they sit pages apart, so you never notice. Here they literally stack in the same column. "Which months start on a Monday?" becomes a glance, not an audit. Useful for recurring schedules, shift rosters, and "same day next month" planning.
+
+**4. Wall calendars don't fit a screen, a wallet, or a sidebar.**
+The entire year is roughly a 12×7 table. It fits a phone screen, a business card, or a corner of a whiteboard.
+
+**5. Mixed-language teams keep separate calendars.**
+Month and weekday labels switch between **English / 中文 / Melayu / Tiếng Việt** without touching the layout — the grid is the same object in any language.
+
+---
+
+## How to read it
+
+```
+                     ┌─────┬─────┬─────┬─────┬─────┬─────┬─────┐
+                     │ Feb │ Jun │ Sep │ Apr │ Jan │ May │ Aug │   ← months, dropped into the
+                     │ Mar │     │ Dec │ Jul │ Oct │     │     │     column of the weekday
+                     │ Nov │     │     │     │     │     │     │     they start on
+ ┌───┬───┬───┬───┬───┼─────┼─────┼─────┼─────┼─────┼─────┼─────┤
+ │ 1 │ 8 │15 │22 │29 │ Sun │ Mon │ Tue │ Wed │ Thu │ Fri │ Sat │
+ │ 2 │ 9 │16 │23 │30 │ Mon │ Tue │ Wed │ Thu │ Fri │ Sat │ Sun │
+ │ 3 │10 │17 │24 │31 │ Tue │ Wed │ Thu │ Fri │ Sat │ Sun │ Mon │
+ │ 4 │11 │18 │25 │   │ Wed │ Thu │ Fri │ Sat │ Sun │ Mon │ Tue │
+ │ 5 │12 │19 │26 │   │ Thu │ Fri │ Sat │ Sun │ Mon │ Tue │ Wed │
+ │ 6 │13 │20 │27 │   │ Fri │ Sat │ Sun │ Mon │ Tue │ Wed │ Thu │
+ │ 7 │14 │21 │28 │   │ Sat │ Sun │ Mon │ Tue │ Wed │ Thu │ Fri │
+ └───┴───┴───┴───┴───┴─────┴─────┴─────┴─────┴─────┴─────┴─────┘
+   dates 1–31                      each row is the week rotated by one
+```
+
+*(month placement shown for 2026)*
+
+**Three steps:**
+
+1. Find your **month** in the header → note its **column**.
+2. Find your **date** in the left block → note its **row**.
+3. The weekday cell at that **row × column** is your answer.
+
+**Worked example — 25 December 2026.**
+`Dec` sits in the **Tue** column (3rd). `25` sits in **row 4**. Row 4 × column 3 → **Fri**. December 25, 2026 is a Friday.
+
+**Why it works.** For a month whose 1st falls on weekday `f`, the weekday of date `d` is `(f + d − 1) mod 7`. The layout splits that sum into two axes: the month column contributes `f`, the date row contributes `(d − 1) mod 7`, and row `r` of the weekday block is the week rotated left by `r` — so cell `[r][f]` holds exactly `weekdays[(f + r) mod 7]`. The `mod 7` on the date axis is why 1, 8, 15, 22, 29 share a row: they are the same weekday, always.
+
+---
 
 ## Features
 
-- **React**: A powerful library for building dynamic user interfaces
-- **Vite**: Next-generation frontend tooling for fast development and optimized builds
-- **Tailwind CSS**: A utility-first CSS framework for rapid UI development
-- **Lucide React**: A collection of beautifully crafted, customizable icons
-- **TypeScript**: A typed superset of JavaScript for enhanced code quality and maintainability
-- **GitHub Actions**: Automated workflows for continuous integration and deployment to GitHub Pages
+| | |
+|---|---|
+| **Any year, one grid** | Step the year with ◀ / ▶, or jump back with **Current Year**. Only the month labels re-flow. |
+| **Today, triangulated** | The current month chip, today's date, and the weekday cell where they intersect are all highlighted at once. |
+| **Crosshair tracing** | Hovering any weekday cell lights its full row and column, so you can follow a lookup without losing your place. |
+| **31-day markers** | Months with 31 days are underlined, as is date `31` — a reminder that not every column runs to the bottom. |
+| **Elapsed days dimmed** | In the current year, dates before today are greyed out. |
+| **Sunday in red** | Across all 7 rotations, so the weekend edge stays findable in a rotated grid. |
+| **4 languages** | English · 中文 · Melayu · Tiếng Việt, switchable live. |
+| **No dependencies for the math** | ~270 lines, native `Date` only — no moment, no date-fns, no timezone surprises. |
+| **Static by construction** | No backend, no network calls, no storage. Builds to plain files; deploys to GitHub Pages. |
 
-## Prerequisites
+---
 
-Before you begin, ensure you have the following installed:
-- Node.js (version 14 or later)
-- npm (usually comes with Node.js)
-- Git
+## Quick start
 
-## Getting Started
-0. Start from an empty directory:
-   ```bash
-   npm create vite@latest react-tailwind-boilerplate -- --template react-ts
-   cd react-tailwind-boilerplate
-   ```
+```bash
+git clone https://github.com/tanghoong/perpetual-calendars.git
+cd perpetual-calendars
+npm install
+npm run dev
+```
 
-1. or Clone the repository:
-   ```bash
-   git clone https://github.com/yourusername/react-tailwind-boilerplate.git
-   cd react-tailwind-boilerplate
-   ```
+Open <http://localhost:5173>.
 
-2. Install dependencies:
-   ```bash
-   npm install
-   npm install -D tailwindcss postcss autoprefixer
-   npm install lucide-react gh-pages
-   npx tailwindcss init -p
-   ```
-   This script will install all necessary npm packages and set up the project.
+> **Heads up:** `npm run build`, `npm run lint`, and `npm start` currently fail on a clean checkout. `npm run dev` works. See [Known issues](#known-issues) for the one-line fixes.
 
-3. Start the development server:
-   ```bash
-   npm run dev
-   ```
-   This will start the Vite development server with hot module replacement.
+### Scripts
 
-4. Open your browser and visit `http://localhost:5173` to see the app in action.
+| Script | What it does | Status |
+|---|---|---|
+| `npm run dev` | Vite dev server with HMR | ✅ works |
+| `npm run build` | `tsc -b && vite build` → `dist/` | ❌ fails — see #1 |
+| `npm run preview` | Serve the production build locally | ✅ (after a successful build) |
+| `npm run lint` | ESLint over the repo | ❌ crashes — see #2 |
+| `npm start` | Serve `dist/` via Express | ❌ fails — see #3 |
+| `npm run deploy` | `gh-pages -d dist` | ⚠️ depends on `build` |
 
-## Development Workflow
+### Project layout
 
-- Edit files in the `src` directory to modify the application.
-- Changes will be reflected in real-time thanks to Vite's hot module replacement.
-- Use Tailwind CSS classes to style your components efficiently.
-- Leverage Lucide React icons for consistent and customizable iconography.
+```
+src/
+  components/CalendarBuilder.tsx   ← the entire app: layout, date math, i18n
+  App.tsx                          ← renders CalendarBuilder
+  main.tsx                         ← React root
+.github/workflows/deploy.yml       ← build + publish to gh-pages on push to main
+server.js                          ← optional Express static server
+```
 
-## Building for Production
+Everything meaningful lives in `CalendarBuilder.tsx`. The functions worth knowing:
 
-When you're ready to create a production build, follow these steps:
+- `getMonthPositions(year)` — buckets the 12 months into 7 columns by their first weekday.
+- `generateWeekdayGrid()` — builds the 7×7 rotation block.
+- `isHighlighted()` — resolves hover crosshair vs. today's intersection.
 
-1. Run the build script:
-   ```bash
-   npm run build
-   ```
+---
 
-2. The optimized production files will be generated in the `dist` directory.
+## Known issues
 
-## Deploying to GitHub Pages
+Verified against a clean `npm ci` on this branch. The first three block the standard workflow, so they're listed with their fixes.
 
-To deploy your app to GitHub Pages:
+### Blocking
 
-1. Ensure your repository is configured for GitHub Pages (Settings > Pages).
-2. Run the deploy script:
-   ```bash
-   npm run deploy
-   ```
+**1. `npm run build` fails — and takes CI down with it.**
+`tsconfig.app.json` sets `noUnusedLocals` / `noUnusedParameters`, and four symbols are unused:
 
-This script will:
-- Build the app for production
-- Push the contents of the `dist` directory to the `gh-pages` branch
-- Update your GitHub Pages site with the latest version of your app
+```
+src/App.tsx(1,1)                     'useState' is declared but never read
+src/components/CalendarBuilder.tsx(1,8)   'React' is declared but never read
+src/components/CalendarBuilder.tsx(1,27)  'useEffect' is declared but never read
+src/components/CalendarBuilder.tsx(28,9)  'currentDay' is declared but never read
+```
 
-## Customization
+Deleting those four declarations fixes it. Because `.github/workflows/deploy.yml` runs `npm run build`, **the deploy workflow fails on every push to `main`** — there is currently no published site.
 
-- **Main Component**: Edit `src/App.tsx` to modify the root component of your application.
-- **Styling**: Update `tailwind.config.js` to customize your Tailwind CSS setup. Refer to the [Tailwind documentation](https://tailwindcss.com/docs/configuration) for more details.
-- **Build Configuration**: Modify `vite.config.ts` to adjust your Vite configuration, such as plugins or build options. See the [Vite documentation](https://vitejs.dev/config/) for available options.
+**2. `npm run lint` crashes.**
+The lockfile resolves ESLint to 9.15 while `typescript-eslint` is pinned at `^8.7`; the `no-unused-expressions` rule then throws `Cannot read properties of undefined (reading 'allowShortCircuit')`. Bump `typescript-eslint` to `^8.15`.
 
-## Project Structure
+**3. `npm start` fails.**
+`server.js` does `import express from 'express'`, but `express` is in neither `dependencies` nor the lockfile. Either add it or drop `server.js` — `npm run preview` already covers local production serving.
 
-- `src/`: Contains the source code of the application.
-  - `assets/`: Static assets like images, fonts, etc.
-  - `components/`: Reusable UI components.
-  - `pages/`: Application pages.
-  - `App.tsx`: The root component.
-  - `main.tsx`: Entry point of the application.
-- `public/`: Static assets that are copied to the build output.
-- `tailwind.config.js`: Tailwind CSS configuration.
-- `vite.config.ts`: Vite configuration.
-- `package.json`: Project dependencies and scripts.
-- `tsconfig.json`: TypeScript configuration.
+### Deployment
+
+**4. Asset paths will 404 on a project page.**
+`vite.config.ts` sets `base: '/'`, but a GitHub Pages project site serves from `/perpetual-calendars/`. Set `base: '/perpetual-calendars/'` (or derive it from `import.meta.env`). Relatedly, `package.json#homepage` is still the boilerplate placeholder `https://username.github.io/react-tailwind-boilerplate/`, and `name` is still `react-tailwind-boilerplate`.
+
+**5. The workflow needs a PAT it may not have.**
+`deploy.yml` authenticates with `secrets.PERSONAL_ACCESS_TOKEN`. The built-in `github_token: ${{ secrets.GITHUB_TOKEN }}` works for same-repo Pages deploys and needs no secret management.
+
+**6. `index.html` is unbranded.**
+Title is still `Vite + React + TS`, the favicon is `vite.svg`, and there is no description or Open Graph tag — which matters for a tool whose main distribution channel is a shared link.
+
+### Correctness and UX
+
+**7. Month lengths aren't modelled.**
+The date block always shows 1–31. February (28/29) and the 30-day months aren't masked, and leap years get no indication — the reader has to supply that knowledge. Dimming out-of-range dates for the hovered month would close the gap.
+
+**8. i18n logic matches on translated strings, not indices.**
+`hasThirtyOneDays()` keeps four parallel arrays of localized month names, and the Sunday-red test is a string check (`day.includes('Sun') || day.includes('周日') || day.includes('Ahd') || day === 'CN'`). Adding a fifth language means editing string lists in two more places, and any label collision across locales silently mis-renders. Both should key off the month/weekday **index**, which is already available.
+
+**9. The crosshair is hover-only.**
+`onMouseEnter`/`onMouseLeave` means touch and keyboard users get no tracing aid at all — on mobile, the single most useful interaction is simply absent. Tap-to-pin plus focus/arrow-key navigation would fix both.
+
+**10. The mobile layout is a rotation hack.**
+Below 768px the whole component is `rotate(90deg) translate(0,-100%)`, which turns the page sideways rather than reflowing. It breaks scroll direction and text selection. A responsive grid or horizontal scroll container would behave properly.
+
+**11. Accessibility gaps.**
+The grid is a `<table>` with no `<th>`, `<caption>`, or `scope` attributes, so screen readers can't announce the row/column relationship the entire design depends on. State (today, past, highlighted) is conveyed by color alone, and the language `<select>` has no associated label.
+
+**12. Nothing is persisted or shareable.**
+Year and language reset on every reload. Reading them from the URL (`?year=2027&lang=zh`) and mirroring to `localStorage` would make a specific view linkable.
+
+**13. No print stylesheet.**
+For a calendar whose entire premise is fitting on one page, `@media print` is a conspicuous omission.
+
+### Housekeeping
+
+**14. Boilerplate residue.** `src/App.css` still ships an unused `.spin-slow` animation; `src/assets/react.svg` and `public/vite.svg` are unused.
+**15. No tests.** The date math (`getMonthPositions`, `generateWeekdayGrid`) is pure and takes a number, returns an array — near-zero-friction to test, and it's the part that must never be wrong.
+**16. No LICENSE file.** The previous README advertised MIT, but no license file was ever committed. See [License](#license).
+
+---
+
+## Deployment
+
+`.github/workflows/deploy.yml` builds on every push to `main` and publishes `dist/` to the `gh-pages` branch via `peaceiris/actions-gh-pages`. Once issues #1, #4, and #5 are resolved, the site will serve from `https://tanghoong.github.io/perpetual-calendars/`.
+
+Manual alternative:
+
+```bash
+npm run deploy   # runs predeploy → build, then pushes dist/ to gh-pages
+```
+
+---
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Issues and pull requests are welcome. The [Known issues](#known-issues) list is roughly in priority order — items 1–3 are small, self-contained, and unblock everyone else.
+
+---
 
 ## License
 
-This project is open source and available under the [MIT License](LICENSE). 
-
-
-
+No license file is currently committed, so default copyright applies — the code is not yet licensed for reuse. If MIT is the intent (as an earlier draft of this README stated), adding a `LICENSE` file would make it official.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import CalendarBuilder from './components/CalendarBuilder'
 import './App.css'
 

--- a/src/components/CalendarBuilder.tsx
+++ b/src/components/CalendarBuilder.tsx
@@ -70,7 +70,7 @@ const CalendarBuilder = () => {
       const firstDay = getFirstDayOfMonth(year, i);
       return firstDay;
     });
-    let columns: string[][] = Array(7).fill(null).map(() => []);
+    const columns: string[][] = Array(7).fill(null).map(() => []);
     positions.forEach((pos, idx) => {
       columns[pos].push(translations[language].months[idx]);
     });
@@ -90,17 +90,21 @@ const CalendarBuilder = () => {
     return grid;
   };
 
-  const isHighlighted = (section: string, rowIdx: number, colIdx: number): boolean => {
-    if (section !== 'weekdays') return false;
-    
+  // Computed once per render — both are pure and were previously rebuilt
+  // inside the row loops, recomputing the same values on every row.
+  const monthPositions = getMonthPositions(year);
+  const weekdayGrid = generateWeekdayGrid();
+  const monthRowCount = Math.max(...monthPositions.map(col => col.length));
+
+  const isHighlighted = (rowIdx: number, colIdx: number): boolean => {
     if (hoverCoords.row !== null || hoverCoords.col !== null) {
       return rowIdx === hoverCoords.row || colIdx === hoverCoords.col;
     }
 
     if (year === currentYear) {
       const currentMonthColumn = getCurrentMonthColumn(year, currentMonth);
-      const currentDateRow = Math.floor((currentDate - 1) % 7);
-      
+      const currentDateRow = (currentDate - 1) % 7;
+
       return colIdx === currentMonthColumn && rowIdx === currentDateRow;
     }
 
@@ -108,11 +112,11 @@ const CalendarBuilder = () => {
   };
 
   const isPastDate = (num: number): boolean => {
-    return year === currentYear && currentMonth === new Date().getMonth() && num < currentDate;
+    return year === currentYear && num < currentDate;
   };
 
   const isToday = (num: number): boolean => {
-    return year === currentYear && num === currentDate && currentMonth === new Date().getMonth();
+    return year === currentYear && num === currentDate;
   };
 
   const hasThirtyOneDays = (monthName: string): boolean => {
@@ -188,14 +192,14 @@ const CalendarBuilder = () => {
           <table className="w-full border-separate border-spacing-[2px]">
             <tbody>
               {/* Month Row */}
-              {Array.from({ length: Math.max(...getMonthPositions(year).map(col => col.length)) }, (_, rowIdx) => (
+              {Array.from({ length: monthRowCount }, (_, rowIdx) => (
                 <tr key={`month-${rowIdx}`}>
                   {/* Left side empty cells to align with date grid */}
                   {[1,2,3,4,5].map((colIdx) => (
                     <td key={`empty-left-${colIdx}`} />
                   ))}
                   {/* Month cells */}
-                  {getMonthPositions(year).map((column, colIdx) => (
+                  {monthPositions.map((column, colIdx) => (
                     <td key={`month-${colIdx}`} className="p-[1px]">
                       {column[rowIdx] && (
                         <div 
@@ -229,7 +233,7 @@ const CalendarBuilder = () => {
                                    ? 'bg-blue-500 text-white' 
                                    : isPastDate(num)
                                      ? 'text-gray-400'
-                                     : 'text-gray-600 hover:bg-gray-10'}
+                                     : 'text-gray-600 hover:bg-gray-100'}
                                  ${num === 31 ? 'underline decoration-2 underline-offset-4' : ''}`}
                         >
                           {num}
@@ -239,16 +243,16 @@ const CalendarBuilder = () => {
                   })}
 
                   {/* Weekday cells */}
-                  {generateWeekdayGrid()[rowIdx].map((day, colIdx) => (
+                  {weekdayGrid[rowIdx].map((day, colIdx) => (
                     <td key={`weekday-${colIdx}`} className="p-[1px]">
                       <div 
                         onMouseEnter={() => setHoverCoords({ row: rowIdx, col: colIdx })}
                         onMouseLeave={() => setHoverCoords({ row: null, col: null })}
                         className={`h-8 flex items-center justify-center rounded-md text-xs font-medium
                                transition-colors duration-150 cursor-pointer
-                               ${isHighlighted('weekdays', rowIdx, colIdx)
-                                 ? 'bg-blue-500 text-white' 
-                                 : 'hover:bg-gray-10'}
+                               ${isHighlighted(rowIdx, colIdx)
+                                 ? 'bg-blue-500 text-white'
+                                 : 'hover:bg-gray-100'}
                                ${(day.includes('Sun') || day.includes('周日') || day.includes('Ahd') || day === 'CN')
                                  ? 'text-red-500'
                                  : 'text-gray-600'}`}

--- a/src/components/CalendarBuilder.tsx
+++ b/src/components/CalendarBuilder.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { ChevronLeft, ChevronRight, RotateCcw } from 'lucide-react';
 
 type Language = 'en' | 'zh' | 'ms' | 'vi';
@@ -25,8 +25,7 @@ const CalendarBuilder = () => {
   const currentYear = today.getFullYear();
   const currentMonth = today.getMonth();
   const currentDate = today.getDate();
-  const currentDay = today.getDay();
-  
+
   const [year, setYear] = useState(currentYear);
   const [hoverCoords, setHoverCoords] = useState<HoverCoords>({ row: null, col: null });
   const [language, setLanguage] = useState<Language>('en');


### PR DESCRIPTION
## Summary

The README was still the untouched Vite + Tailwind boilerplate template — it described a generic starter kit and never once mentioned a calendar. This replaces it with documentation of the project that actually exists.

Auditing the code to write that README turned up a broken build and a handful of dead or redundant code paths, which are fixed here too.

## Documentation

**Pain points.** New opening section explaining *why* the single-grid layout is worth using instead of a conventional 12-block calendar: one-intersection lookups, a year-invariant grid (only the 12 month labels re-flow when the year changes, which is what makes it perpetual), months that share a start weekday stacking visibly in one column, and a footprint that fits a phone screen.

**How to read it.** An annotated ASCII diagram of the layout (month placement shown for 2026), a three-step lookup guide, a worked example (25 Dec 2026 → Friday), and the derivation behind the design — `weekday = (f + d − 1) mod 7`, split across the two axes so that cell `[r][f]` resolves to `weekdays[(f + r) mod 7]`.

**Features.** What `CalendarBuilder.tsx` actually implements: year stepping with a current-year reset, simultaneous highlighting of current month / today / their intersection, the hover crosshair, 31-day underline markers, Sunday in red across all rotations, and live switching between English / 中文 / Melayu / Tiếng Việt.

**Known issues.** A prioritized section, verified against a clean `npm ci` rather than inferred: the crashing lint script, the failing `npm start`, the Pages base-path and token problems, unmodelled month lengths, i18n logic matching on translated strings instead of indices, the hover-only crosshair leaving touch users without the main interaction, the `rotate(90deg)` mobile layout, table accessibility gaps, no persisted or shareable state, and no tests.

**License.** The old README advertised MIT, but no `LICENSE` file was ever committed. The License section now states that plainly instead of repeating the claim.

## Code fixes

**The build was broken on `main`.** `tsconfig.app.json` enables `noUnusedLocals`, and four dead symbols failed `tsc -b`: an unused `useState` import in `App.tsx`, unused `React` and `useEffect` imports in `CalendarBuilder.tsx` (the project uses the react-jsx transform), and an unused `currentDay` local. Since `.github/workflows/deploy.yml` runs `npm run build`, this failed the deploy workflow on every push to `main` — the site was never published. `npm run build` now succeeds.

**The hover background never rendered.** Date cells and weekday cells both used `hover:bg-gray-10`, which is not a Tailwind class — the gray scale starts at 50 — so it compiled to nothing. Now `hover:bg-gray-100`, and the compiled CSS carries the rule. This is the only user-visible change in the PR.

**Redundant code removed**, all behavior-preserving:

- `isPastDate()` and `isToday()` tested `currentMonth === new Date().getMonth()`, always true since `currentMonth` derives from the same `today`.
- `isHighlighted()` took a `section` parameter and returned early unless it was `'weekdays'`, but the sole call site always passed `'weekdays'`.
- `Math.floor()` applied to an integer modulo result is a no-op.
- `getMonthPositions()` and `generateWeekdayGrid()` were called inside the row loops, rebuilding identical arrays on every row — 8+ calls per render, now one each.
- `let columns` → `const columns`; never reassigned.

## Review feedback addressed

- The "elapsed days dimmed" feature was overstated. `isPastDate()` compares `num < currentDate` on date cells shared by all twelve months, making it a day-of-month comparison — it dims numbers still in the future for later months and leaves the 29th–31st of elapsed months undimmed. Described as implemented, with the analysis folded into known issue #6, which shares a root cause with the unmasked month lengths.
- Recommending `secrets.GITHUB_TOKEN` over a PAT skipped a prerequisite: `deploy.yml` declares no `permissions` block, so where the default workflow token is read-only it still cannot push `gh-pages`. The required `permissions: contents: write` grant is now noted.

## Not addressed here

Two items need a design decision rather than a fix, and are documented instead:

- Making the dimming and month-length masking correct requires introducing a selected/hovered month as the reference point.
- `today` is captured at render with no timer, so the highlight goes stale past midnight until the next re-render.